### PR TITLE
Disable Merlin WP

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -911,3 +911,8 @@ require get_theme_file_path( '/inc/widgets/widget-clients.php' );
  * Admin specific functions.
  */
 require get_parent_theme_file_path( '/inc/admin/init.php' );
+
+/**
+ * Disable Merlin WP.
+ */
+function themebeans_merlin() {}


### PR DESCRIPTION
The sandbox servers are no longer available, which is where the demo content is pulled from. Eventually we could remap where the demo content is coming from.